### PR TITLE
FRW-2289 Backport for fixed propel-orm introduced BC-break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=7.4",
-        "propel/propel": "2.0.0-beta2",
+        "propel/propel": "2.0.0-beta1 || 2.0.0-beta2",
         "spryker/config": "^3.0.0",
         "spryker/error-handler": "^2.0.0",
         "spryker/kernel": "^3.67.0",

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionObjectBuilder.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionObjectBuilder.php
@@ -15,6 +15,8 @@ use Propel\Generator\Builder\Om\ExtensionObjectBuilder as PropelExtensionObjectB
 
 class ExtensionObjectBuilder extends PropelExtensionObjectBuilder
 {
+    use ExtensionObjectBuilderTrait;
+
     /**
      * @var int
      */
@@ -30,7 +32,7 @@ class ExtensionObjectBuilder extends PropelExtensionObjectBuilder
      *
      * @return string
      */
-    public function getUseStatements(?string $ignoredNamespace = null): string
+    public function executeGetUseStatements(?string $ignoredNamespace = null): string
     {
         $script = '';
         $declaredClasses = $this->declaredClasses;

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionObjectBuilderTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionObjectBuilderTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait CommonExtensionObjectBuilderTrait
+{
+    protected abstract function executeGetUseStatements(?string $ignoredNamespace = null): string;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ExtensionObjectBuilderTrait
+    {
+        use CommonExtensionObjectBuilderTrait;
+
+        /**
+         * @param string|null $ignoredNamespace
+         *
+         * @return string
+         */
+        public function getUseStatements(?string $ignoredNamespace = null): string
+        {
+            $this->executeGetUseStatements($ignoredNamespace);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ExtensionObjectBuilderTrait
+    {
+        use CommonExtensionObjectBuilderTrait;
+
+        /**
+         * @param $ignoredNamespace
+         *
+         * @return void
+         */
+        public function getUseStatements($ignoredNamespace = null)
+        {
+            $this->executeGetUseStatements($ignoredNamespace);
+        }
+    }
+}

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionQueryBuilder.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionQueryBuilder.php
@@ -15,6 +15,8 @@ use Propel\Generator\Builder\Om\ExtensionQueryBuilder as PropelExtensionQueryObj
 
 class ExtensionQueryBuilder extends PropelExtensionQueryObjectBuilder
 {
+    use ExtensionQueryBuilderTrait;
+
     /**
      * @var int
      */

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionQueryBuilderTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ExtensionQueryBuilderTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait CommonExtensionQueryBuilderTrait
+{
+    protected abstract function executeGetUseStatements(?string $ignoredNamespace = null): string;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ExtensionQueryBuilderTrait
+    {
+        use CommonExtensionQueryBuilderTrait;
+
+        /**
+         * @param string|null $ignoredNamespace
+         *
+         * @return string
+         */
+        public function getUseStatements(?string $ignoredNamespace = null): string
+        {
+            return $this->executeGetUseStatements($ignoredNamespace);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ExtensionQueryBuilderTrait
+    {
+        use CommonExtensionQueryBuilderTrait;
+
+        /**
+         * @param $ignoredNamespace
+         *
+         * @return void
+         */
+        public function getUseStatements($ignoredNamespace = null)
+        {
+            $this->executeGetUseStatements($ignoredNamespace);
+        }
+    }
+}

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilder.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilder.php
@@ -24,6 +24,7 @@ use Spryker\Zed\Kernel\Business\FactoryResolverAwareTrait as BusinessFactoryReso
  */
 class ObjectBuilder extends PropelObjectBuilder
 {
+    use ObjectBuilderTrait;
     use BusinessFactoryResolverAwareTrait;
 
     /**
@@ -51,7 +52,7 @@ class ObjectBuilder extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addBooleanMutator(string &$script, Column $col): void
+    protected function executeAddBooleanMutator(string &$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -102,7 +103,7 @@ class ObjectBuilder extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addDefaultMutator(string &$script, Column $col): void
+    protected function executeAddDefaultMutator(string &$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -145,7 +146,7 @@ class ObjectBuilder extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addClassBody(string &$script): void
+    protected function executeAddClassBody(string &$script): void
     {
         $classes = $this->getFactory()
             ->createtPostSaveClassNamespacesCollector()
@@ -165,7 +166,7 @@ class ObjectBuilder extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addHookMethods(string &$script): void
+    protected function executeAddHookMethods(string &$script): void
     {
         $hooks = [];
         foreach (['pre', 'post'] as $hook) {
@@ -190,7 +191,7 @@ class ObjectBuilder extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addSaveClose(string &$script): void
+    protected function executeAddSaveClose(string &$script): void
     {
         $script .= "
     }

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderTrait.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+use Propel\Generator\Model\Column;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait CommonObjectBuilderTrait
+{
+    /**
+     * @param string $script
+     * @param \Propel\Generator\Model\Column $col
+     *
+     * @return void
+     */
+    protected abstract function executeAddBooleanMutator(string &$script, Column $col): void;
+
+    /**
+     * @param string $script
+     * @param \Propel\Generator\Model\Column $col
+     *
+     * @return void
+     */
+    protected abstract function executeAddDefaultMutator(string &$script, Column $col): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddClassBody(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddHookMethods(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddSaveClose(string &$script): void;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ObjectBuilderTrait
+    {
+        use CommonObjectBuilderTrait;
+
+        /**
+         * @param string $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        public function addBooleanMutator(string &$script, Column $col): void
+        {
+            $this->executeAddBooleanMutator($script, $col);
+        }
+
+        /**
+         * @param string $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        protected function addDefaultMutator(string &$script, Column $col): void
+        {
+            $this->executeAddDefaultMutator($script, $col);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addClassBody(string &$script): void
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addHookMethods(string &$script): void
+        {
+            $this->executeAddHookMethods($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function executeAddSaveClose(string &$script): void
+        {
+            $this->executeAddSaveClose($script);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ObjectBuilderTrait
+    {
+        use CommonObjectBuilderTrait;
+
+        /**
+         * @param $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        protected function addBooleanMutator(&$script, Column $col)
+        {
+            return $this->executeAddBooleanMutator($script, $col);
+        }
+
+        /**
+         * @param $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        protected function addDefaultMutator(&$script, Column $col)
+        {
+            $this->executeAddDefaultMutator($script, $col);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addClassBody(&$script)
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addHookMethods(&$script)
+        {
+            $this->executeAddHookMethods($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function executeAddSaveClose(&$script)
+        {
+            $this->executeAddSaveClose($script);
+        }
+    }
+}

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderWithLogger.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderWithLogger.php
@@ -26,6 +26,7 @@ use Spryker\Zed\Kernel\Business\FactoryResolverAwareTrait as BusinessFactoryReso
  */
 class ObjectBuilderWithLogger extends PropelObjectBuilder
 {
+    use ObjectBuilderWithLoggerTrait;
     use BusinessFactoryResolverAwareTrait;
 
     /**
@@ -53,7 +54,7 @@ class ObjectBuilderWithLogger extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addBooleanMutator(string &$script, Column $col): void
+    protected function executeAddBooleanMutator(string &$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -104,7 +105,7 @@ class ObjectBuilderWithLogger extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addClassBody(string &$script): void
+    protected function executeAddClassBody(string &$script): void
     {
         $classes = $this->getFactory()
             ->createtPostSaveClassNamespacesCollector()
@@ -199,7 +200,7 @@ class ObjectBuilderWithLogger extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addDeleteClose(string &$script): void
+    protected function executeAddDeleteClose(string &$script): void
     {
         $script .= "
         \\Spryker\\Shared\\Log\\LoggerFactory::getInstance()->info('Entity delete', ['entity' => \$this->toArray('fieldName', false)]);
@@ -214,7 +215,7 @@ class ObjectBuilderWithLogger extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addHookMethods(string &$script): void
+    protected function executeAddHookMethods(string &$script): void
     {
         $hooks = [];
         foreach (['pre', 'post'] as $hook) {
@@ -239,7 +240,7 @@ class ObjectBuilderWithLogger extends PropelObjectBuilder
      *
      * @return void
      */
-    protected function addSaveClose(string &$script): void
+    protected function executeAddSaveClose(string &$script): void
     {
         $script .= "
     }

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderWithLoggerTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/ObjectBuilderWithLoggerTrait.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+use Propel\Generator\Model\Column;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait CommonObjectBuilderWithLoggerTrait
+{
+    /**
+     * @param string $script
+     * @param \Propel\Generator\Model\Column $col
+     *
+     * @return void
+     */
+    protected abstract function executeAddBooleanMutator(string &$script, Column $col): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddClassBody(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddHookMethods(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddSaveClose(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddDeleteClose(string &$script): void;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ObjectBuilderWithLoggerTrait
+    {
+        use CommonObjectBuilderWithLoggerTrait;
+
+        /**
+         * @param string $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        public function addBooleanMutator(string &$script, Column $col): void
+        {
+            $this->executeAddBooleanMutator($script, $col);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addClassBody(string &$script): void
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addHookMethods(string &$script): void
+        {
+            $this->executeAddHookMethods($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function executeAddSaveClose(string &$script): void
+        {
+            $this->executeAddSaveClose($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addDeleteClose(string &$script): void
+        {
+            $this->executeAddDeleteClose($script);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait ObjectBuilderWithLoggerTrait
+    {
+        use CommonObjectBuilderWithLoggerTrait;
+
+        /**
+         * @param $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        protected function addBooleanMutator(&$script, Column $col)
+        {
+            return $this->executeAddBooleanMutator($script, $col);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addClassBody(&$script)
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addHookMethods(&$script)
+        {
+            $this->executeAddHookMethods($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function executeAddSaveClose(&$script)
+        {
+            $this->executeAddSaveClose($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addDeleteClose(&$script)
+        {
+            $this->executeAddDeleteClose($script);
+        }
+    }
+}

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/QueryBuilder.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/QueryBuilder.php
@@ -25,6 +25,7 @@ use Spryker\Zed\PropelOrm\Business\Runtime\ActiveQuery\Criteria;
  */
 class QueryBuilder extends PropelQueryBuilder
 {
+    use QueryBuilderTrait;
     use BusinessFactoryResolverAwareTrait;
 
     /**
@@ -37,7 +38,7 @@ class QueryBuilder extends PropelQueryBuilder
      *
      * @return string
      */
-    protected function addFilterByColIn(Column $col): string
+    protected function executeAddFilterByCol(Column $col): string
     {
         $script = '';
 
@@ -413,7 +414,7 @@ SCRIPT;
      *
      * @return void
      */
-    protected function addClassBody(string &$script): void
+    protected function executeAddClassBody(string &$script): void
     {
         $classes = $this->getFactory()
             ->createFindClassNamespacesCollector()
@@ -498,7 +499,7 @@ SCRIPT;
      *
      * @return void
      */
-    protected function addFindPk(string &$script): void
+    protected function executeAddFindPk(string &$script): void
     {
         $class = $this->getObjectClassName();
         $tableMapClassName = $this->getTableMapClassName();
@@ -598,7 +599,7 @@ SCRIPT;
      *
      * @return void
      */
-    protected function addFindPks(string &$script): void
+    protected function executeAddFindPks(string &$script): void
     {
         $this->declareClasses(
             '\Propel\Runtime\Collection\ObjectCollection',

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/QueryBuilderTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/QueryBuilderTrait.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+use Propel\Generator\Model\Column;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait CommonQueryBuilderTrait
+{
+    /**
+     * @param \Propel\Generator\Model\Column $col
+     *
+     * @return string
+     */
+    protected abstract function executeAddFilterByCol(Column $col): string;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddClassBody(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddFindPk(string &$script): void;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddFindPks(string &$script): void;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait QueryBuilderTrait
+    {
+        use CommonQueryBuilderTrait;
+
+        /**
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return string
+         */
+        protected function addFilterByCol(Column $col): string
+        {
+            return $this->executeAddFilterByCol($col);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addClassBody(string &$script): void
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addFindPk(string &$script): void
+        {
+            $this->executeAddFindPk($script);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addFindPks(string &$script): void
+        {
+            $this->executeAddFindPks($script);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait QueryBuilderTrait
+    {
+        use CommonQueryBuilderTrait;
+
+        /**
+         * @param $script
+         * @param \Propel\Generator\Model\Column $col
+         *
+         * @return void
+         */
+        protected function addFilterByCol(&$script, Column $col)
+        {
+            $this->executeAddFilterByCol($script, $col);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addClassBody(&$script)
+        {
+            $this->executeAddClassBody($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addFindPk(&$script)
+        {
+            $this->executeAddFindPk($script);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addFindPks(&$script)
+        {
+            $this->executeAddFindPks($script);
+        }
+    }
+}

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/TableMapBuilder.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/TableMapBuilder.php
@@ -16,6 +16,8 @@ use Propel\Generator\Builder\Om\TableMapBuilder as PropelTableMapBuilder;
 
 class TableMapBuilder extends PropelTableMapBuilder
 {
+    use TableMapBuilderTrait;
+
     /**
      * Changes default Propel behavior.
      *
@@ -24,7 +26,7 @@ class TableMapBuilder extends PropelTableMapBuilder
      *
      * @return string
      */
-    public function buildObjectInstanceCreationCode(string $objName, string $clsName): string
+    public function executeBuildObjectInstanceCreationCode(string $objName, string $clsName): string
     {
         $bundle = $this->getBundleName();
 
@@ -58,7 +60,7 @@ class TableMapBuilder extends PropelTableMapBuilder
      *
      * @return void
      */
-    protected function addPopulateObject(string &$script): void
+    protected function executeAddPopulateObject(string &$script): void
     {
         $table = $this->getTable();
         $script .= '

--- a/src/Spryker/Zed/PropelOrm/Business/Builder/TableMapBuilderTrait.php
+++ b/src/Spryker/Zed/PropelOrm/Business/Builder/TableMapBuilderTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the Propel package - modified by Spryker Systems GmbH.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with the source code of the extended class.
+ *
+ * @license MIT License
+ * @see https://github.com/propelorm/Propel2
+ */
+
+namespace Spryker\Zed\PropelOrm\Business\Builder;
+
+/**
+ * @deprecated Will be removed without replacement. Exists only for BC reasons.
+ */
+trait TableMapBuilderTrait
+{
+    /**
+     * @param string $objName
+     * @param string $clsName
+     *
+     * @return string
+     */
+    public abstract function executeBuildObjectInstanceCreationCode(string $objName, string $clsName): string;
+
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
+    protected abstract function executeAddPopulateObject(string &$script): void;
+}
+
+if (class_exists('Propel\Runtime\ActiveQuery\Criterion\ExistsQueryCriterion')) {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait QueryBuilderTrait
+    {
+        use TableMapBuilderTrait;
+
+        /**
+         * @param string $objName
+         * @param string $clsName
+         *
+         * @return string
+         */
+        public function buildObjectInstanceCreationCode(string $objName, string $clsName): string
+        {
+            return $this->executeBuildObjectInstanceCreationCode($objName, $clsName);
+        }
+
+        /**
+         * @param string $script
+         *
+         * @return void
+         */
+        protected function addPopulateObject(string &$script): void
+        {
+            $this->executeAddPopulateObject($script);
+        }
+    }
+} else {
+    /**
+     * @deprecated Will be removed without replacement. Exists only for BC reasons.
+     */
+    trait QueryBuilderTrait
+    {
+        use TableMapBuilderTrait;
+
+        /**
+         * @param $objName
+         * @param $clsName
+         *
+         * @return string
+         */
+        public function buildObjectInstanceCreationCode($objName,$clsName)
+        {
+            return $this->executeBuildObjectInstanceCreationCode($objName, $clsName);
+        }
+
+        /**
+         * @param $script
+         *
+         * @return void
+         */
+        protected function addPopulateObject(&$script)
+        {
+            $this->executeAddPopulateObject($script);
+        }
+    }
+}


### PR DESCRIPTION
- Developers: @asmarovydlo @yaroslav-spryker 

- Ticket: https://spryker.atlassian.net/browse/FRW-2289

- Release Group: https://release.spryker.com/release-groups/view/4908

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PropelOrm               | patch                 |                       |

-----------------------------------------

#### Module PropelOrm

##### Change log

Fixes

- Fixed code to support 2 beta versions of Propel dependency.
